### PR TITLE
removed multi-tenent ref in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,3 @@
 ## Related issues
 
 > Fix [#1]() 
-
-## Describe multi-tenancy segmentation
-


### PR DESCRIPTION
## Description of the change

removed multi-tenent ref in PR template

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

