### PR TITLE
Fix pull request template to point to tracking repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@
 
 ## Related issues
 
-> Fix [#1]() 
+Fix refractionPOINT/tracking#1


### PR DESCRIPTION
## Description of the change

This PR changes pull request template to suggest linking new PRs to issues in [refractionPOINT/tracking](https://github.com/refractionPOINT/tracking) repo rather than to the issues in the the same repo the PR has been created it. This should help us maintain better connection with tracking issues with less effort on the engineers part.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 
