### PR TITLE
Fix Dependabot auto-merge ecosystem check (gomod -> go_modules)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Auto-merge Go minor and patch security updates
         if: |
-          steps.metadata.outputs.package-ecosystem == 'gomod' &&
+          steps.metadata.outputs.package-ecosystem == 'go_modules' &&
           steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |
           gh pr review --approve "$PR_URL"


### PR DESCRIPTION
## Summary
The reusable auto-merge workflow checks `steps.metadata.outputs.package-ecosystem == 'gomod'`, but `dependabot/fetch-metadata@v2` emits `go_modules` for that output. `gomod` is only the key used in `dependabot.yml`, not the value coming back from the action. As a result the conditional never matched and `--auto` was never enabled on dependabot Go PRs in any caller repo.

Verified against the analogous caller-workflow run output on refractionPOINT/go-essentials#749:
```
outputs.package-ecosystem: go_modules
```

No repo currently consumes this reusable workflow yet, so this fix only unblocks the future caller-workflow rollout.

## Test plan
- [ ] CI green
- [ ] After merge, set up a caller repo using this reusable and verify auto-merge fires on a dependabot Go PR